### PR TITLE
Add script to create consensus of DWLS, EpiDISH and FARDEEP

### DIFF
--- a/Modules/Res_explore/Snakefile
+++ b/Modules/Res_explore/Snakefile
@@ -149,7 +149,7 @@ rule getConsensus:
     input:
         'Output/{sample}_res_EpiDISH.rds',
         'Output/{sample}_res_FARDEEP.rds',
-        'Output/{sample}_res_DWLS.rds',
+        'Output/{sample}_res_DWLS.rds'
 
     output:
         getConsensus('{sample}')

--- a/Modules/Res_explore/Snakefile
+++ b/Modules/Res_explore/Snakefile
@@ -143,3 +143,26 @@ rule getHeatmap:
 
     shell:
         "Rscript Modules/Res_explore/Heatmap_agr.R {wildcards.sample}"
+
+
+rule getConsensus:
+    input:
+        'Output/{sample}_res_EpiDISH.rds',
+        'Output/{sample}_res_FARDEEP.rds',
+        'Output/{sample}_res_DWLS.rds',
+
+    output:
+        getConsensus('{sample}')
+
+    conda:
+        "env.yaml"
+
+    resources:
+        mem_mb=getMB(config['mem_gb']['resultsExp'])
+
+    shell:
+        """
+        mkdir -p Consensus
+        mkdir -p ConsensusPlot
+        Rscript Modules/Res_explore/getConsensus.R {wildcards.sample}
+        """

--- a/Modules/Res_explore/env.yaml
+++ b/Modules/Res_explore/env.yaml
@@ -249,3 +249,4 @@ dependencies:
   - xz
   - zlib
   - zstd
+  - r-polychrome

--- a/Modules/Res_explore/getConsensus.R
+++ b/Modules/Res_explore/getConsensus.R
@@ -38,10 +38,10 @@ sampleName <- commandArgs(trailingOnly = TRUE)
 
 #Get files as list 
 #only select DWLS, EpiDISH and FARDEEP proportions for consensus
-filenames <- list.files("Output/", pattern="DWLS|EpiDISH|FARDEEP") 
-            %>% lapply(., function(x) { x <- paste0("Output/", x) }) 
-            %>% lapply(., function(x) { grep(sampleName, x, value = TRUE) }) 
-            %>% .[lengths(.)!=0] %>% as.character(.)
+filenames <- list.files("Output/", pattern="DWLS|EpiDISH|FARDEEP") %>% 
+             lapply(., function(x) { x <- paste0("Output/", x) }) %>% 
+             lapply(., function(x) { grep(sampleName, x, value = TRUE) }) %>% 
+             .[lengths(.)!=0] %>% as.character(.)
 
 files <- lapply(filenames, readRDS)
 names(files) <- lapply(filenames, function(x) gsub("Output/.*res_(.*).rds", "\\1", x))

--- a/Modules/Res_explore/getConsensus.R
+++ b/Modules/Res_explore/getConsensus.R
@@ -1,0 +1,113 @@
+# script to get and plot average of DWLS, FARDEEP and EpiDISH
+# and calculate average correlation between the three methods
+# @nadjano
+
+suppressMessages(library(dplyr))
+#install.packages("Polychrome", repos='http://cran.us.r-project.org')
+library(Polychrome)
+
+CiberBarFrazer <- function(ciber, colors, main0, legy){
+    ## function to get barplot per sample
+    ## from https://github.com/mkrdonovan/gtex_deconvolution
+    par(mar = c(2, 4, 2, 0.5))
+    
+    nsamples =nrow(ciber)
+    ciber = as.data.frame(t(ciber) * 100)
+    
+    ciber$color = colors[ match(colors$celltypes, rownames(ciber)),  "color"]
+    barplot(as.matrix(ciber[, seq(1, (ncol(ciber) - 1))]), 
+            las = 2, 
+            col = ciber$color, 
+            border=NA, 
+            names.arg = rep("", ncol(ciber) - 1), 
+            ylab = "Fraction clusters", 
+            main = main0, 
+            space=0, 
+            cex.main = 1)
+
+    text(nsamples * .05, 90, paste("n = ", nsamples, sep = ""), pos = 4, cex = 1)
+
+    legend(nsamples * .05, legy, gsub("_", " ", colors$celltypes), bty = "n",
+           pch = rep(22, nrow(colors)),
+           pt.cex = rep(4, nrow(colors)),
+           pt.bg = colors$color,
+           y.intersp = 1, cex = 1.1
+          )   
+}
+sampleName <- commandArgs(trailingOnly = TRUE)
+
+#Get files as list 
+#only select DWLS, EpiDISH and FARDEEP proportions for consensus
+filenames <- list.files("Output/", pattern="DWLS|EpiDISH|FARDEEP") 
+            %>% lapply(., function(x) { x <- paste0("Output/", x) }) 
+            %>% lapply(., function(x) { grep(sampleName, x, value = TRUE) }) 
+            %>% .[lengths(.)!=0] %>% as.character(.)
+
+files <- lapply(filenames, readRDS)
+names(files) <- lapply(filenames, function(x) gsub("Output/.*res_(.*).rds", "\\1", x))
+
+for (i in 1:length(files)){
+    files[[i]] <- files[[i]][,order(colnames(files[[i]]))]
+    files[[i]] <- files[[i]][order(rownames(files[[i]])),]
+  }
+  # Calculate Pearson correlation for each RUN between the three methods
+  # to see if the difference between methods is too big
+  mean_vector <- numeric()
+  for (i in 1:dim(files[[1]])[2]) {
+    cor_mat <- cor(data.frame(files[[1]][, i], files[[2]][, i], files[[3]][, i]))
+    
+    # Set diagonal to NA
+    diag(cor_mat) <- NA
+    
+    mean_value <- mean(cor_mat, na.rm = TRUE)
+    mean_vector[i] <- mean_value
+  }
+  
+  mean_corr_all = round(mean(mean_vector), 3)
+  # Check mean correlation
+  if (mean(mean_vector) > 0.6) {
+    cat(paste0('mean_correlation:', round(mean(mean_vector), 3)))
+  } else {
+    cat(paste0('correlation_between_methods_lower_than_0.6'))
+  }
+
+#get average proportions per sample and celltype accros the three methods
+sum_props = Reduce('+',files)
+prop = sum_props/length(files)
+#Save consensus proportions
+saveRDS(prop, paste0("Consensus/",sampleName, "_consensus.rds"))
+
+
+#get sd
+vec <- unlist(files, use.names = TRUE)
+DIM <- dim(files[[1]])
+n <- length(files)
+
+list.mean <- tapply(vec, rep(1:prod(DIM),times = n), mean)
+attr(list.mean, "dim") <- DIM
+list.mean <- as.data.frame(list.mean)
+
+list.sd <- tapply(vec, rep(1:prod(DIM),times = n), sd)
+attr(list.sd, "dim") <- DIM
+list.sd <- as.data.frame(list.sd)
+colnames(list.sd) = colnames(files[[1]])
+
+sd_norm = rowMeans(list.sd)/rowMeans(list.mean)
+prop = data.frame(t(prop))
+
+#add sd to columnames 
+colnames(prop) = paste0(colnames(prop), '(sd=', 100* round(rowMeans(list.sd),3), ')')
+#order to have largest proportions first
+top = names(prop[order(colSums(prop), decreasing = T)][1])
+second_top = names(prop[order(colSums(prop), decreasing = T)][2])
+third_top = names(prop[order(colSums(prop), decreasing = T)][3])
+color = data.frame(celltypes = colnames(prop),
+                   name      =  colnames(prop),
+                   color     =  sky.colors(ncol(prop)))
+
+png(filename = paste0("ConsensusPlot/",sampleName, "_consensus.png"), 
+    width = 500*3, 
+    height = 500*3, 
+    res=300)
+CiberBarFrazer(prop[order(-prop[top], -prop[second_top], -prop[third_top]),], color, paste(sampleName, '_', mean_corr_all), 90)
+dev.off()

--- a/bin/Snakefile
+++ b/bin/Snakefile
@@ -229,6 +229,11 @@ if not config['realBulk-noProp']:
         input:
             expand(getRunSums('{sampleName}'), sampleName = config['sampleNames'])
 
+elif config['getConsenus']:
+    rule all:
+        input:
+            expand(getConsensus('{sampleName}'), sampleName = config['sampleNames'])
+
 else:
     rule all:
         input:

--- a/bin/Snakefile
+++ b/bin/Snakefile
@@ -229,7 +229,7 @@ if not config['realBulk-noProp']:
         input:
             expand(getRunSums('{sampleName}'), sampleName = config['sampleNames'])
 
-elif config['getConsenus']:
+elif config['getConsensus']:
     rule all:
         input:
             expand(getConsensus('{sampleName}'), sampleName = config['sampleNames'])

--- a/bin/Snakefile
+++ b/bin/Snakefile
@@ -177,6 +177,8 @@ def getPhenData(inList, sampleName):
 
         return inList
 
+def getConsensus(sampleName):
+    return str("ConsensusPlot/" + sampleName + "_consensus.png")
 
 
 #Prep metamodule

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -6,6 +6,7 @@ sampleNames: #Enter the part BEFORE file extension (ex. 'data.h5ad' should be en
 seededRun: 0 #Use if you want this run of the pipeline to be reproducible (0-1)
 realBulk: 0 #Use if you are going to test with real data with known proportions (0-1)
 realBulk-noProp: 0 #Use to get results only if no ground truths are present
+getConsenus: 0 #Use to get consensus of FARDEEP, DWLS and EpiDish as final output, make sure to include these three methods under deconMethods
 
 
 cores:

--- a/bin/config.yaml
+++ b/bin/config.yaml
@@ -6,7 +6,7 @@ sampleNames: #Enter the part BEFORE file extension (ex. 'data.h5ad' should be en
 seededRun: 0 #Use if you want this run of the pipeline to be reproducible (0-1)
 realBulk: 0 #Use if you are going to test with real data with known proportions (0-1)
 realBulk-noProp: 0 #Use to get results only if no ground truths are present
-getConsenus: 0 #Use to get consensus of FARDEEP, DWLS and EpiDish as final output, make sure to include these three methods under deconMethods
+getConsensus: 0 #Use to get consensus of FARDEEP, DWLS and EpiDISH as final output, make sure to include these three methods under deconMethods
 
 
 cores:


### PR DESCRIPTION

## Summary

This pull request introduces a script and additional parameters to calculate the consensus of cell type proportions predicted by three different deconvolution methods: FARDEEP, EpiDISH, and DWLS. The consensus is determined by running the pipeline with the `getConsensus` parameter set to `1` in the `config.yaml` file. The resulting consensus data will be saved under the directory `Consensus/{sampleName}_consensus.rds`, and a barplot displaying the average proportions will be saved in `ConsensusPlot/{sampleName}_consensus.png`.

## Changes Made

1. Added a script and parameters for calculating consensus cell type proportions.
2. Modified the `config.yaml` file to include the `getConsensus` parameter.
3. Created a directory structure for storing the consensus data and plots.
4. Implemented the creation of a barplot for visualizing the consensus results.

## Consensus Barplot

The consensus barplot provides an overview of the cell type proportions for each sample. The header of the barplot includes the sample name and the mean correlation between the results from FARDEEP, DWLS, and EpiDISH across all samples. Here is an example of how the consensus plots look:

![Consensus Barplot](https://github.com/Functional-Genomics/CATD_snakemake/assets/103439290/a1b1fab4-3657-4917-b3c4-15f83bd806a8)
